### PR TITLE
make it support fragment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,4 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-
 buildscript {
     repositories {
         jcenter()
@@ -14,10 +13,12 @@ buildscript {
         // in the individual module build.gradle files
     }
 }
-
 allprojects {
     repositories {
         jcenter()
         mavenCentral()
     }
+}
+
+dependencies {
 }

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "23.0.2"
 
     defaultConfig {
         applicationId "com.jude.imageprovider"

--- a/imageprovider/build.gradle
+++ b/imageprovider/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "23.0.2"
 
     defaultConfig {
         minSdkVersion 14

--- a/imageprovider/src/main/java/com/jude/library/imageprovider/ImageProvider.java
+++ b/imageprovider/src/main/java/com/jude/library/imageprovider/ImageProvider.java
@@ -6,6 +6,7 @@ import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Environment;
 import android.provider.MediaStore;
+import android.support.v4.app.Fragment;
 import android.util.Log;
 
 import com.jude.library.imageprovider.album.MultiImageSelectorActivity;
@@ -23,6 +24,7 @@ import java.util.List;
 public class ImageProvider {
 
     private Activity act;
+    private Fragment mFragment;
 
     private OnImageSelectListener mListener;
 
@@ -50,13 +52,24 @@ public class ImageProvider {
         dir.mkdir();
     }
 
+    public ImageProvider(Fragment fragment){
+        this.mFragment = fragment;
+        Utils.initialize(act.getApplication(), "imageLog");
+        dir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
+        dir.mkdir();
+    }
+
     public void getImageFromAlbum(OnImageSelectListener mListener,int maxCount){
         this.mListener = mListener;
         Intent intent = new Intent(act, MultiImageSelectorActivity.class);
         intent.putExtra(MultiImageSelectorActivity.EXTRA_SHOW_CAMERA, false);
         intent.putExtra(MultiImageSelectorActivity.EXTRA_SELECT_MODE, MultiImageSelectorActivity.MODE_MULTI);
         intent.putExtra(MultiImageSelectorActivity.EXTRA_SELECT_COUNT, maxCount);
-        act.startActivityForResult(intent, REQUEST_ALBUM);
+        if (act == null) {
+            mFragment.startActivityForResult(intent, REQUEST_ALBUM);
+        }else{
+            act.startActivityForResult(intent, REQUEST_ALBUM);
+        }
     }
 
     public void getImageFromAlbum(OnImageSelectListener mListener){
@@ -64,7 +77,11 @@ public class ImageProvider {
         Intent intent = new Intent(act, MultiImageSelectorActivity.class);
         intent.putExtra(MultiImageSelectorActivity.EXTRA_SHOW_CAMERA, false);
         intent.putExtra(MultiImageSelectorActivity.EXTRA_SELECT_MODE, MultiImageSelectorActivity.MODE_SINGLE);
-        act.startActivityForResult(intent, REQUEST_ALBUM);
+        if (act == null) {
+            mFragment.startActivityForResult(intent, REQUEST_ALBUM);
+        }else{
+            act.startActivityForResult(intent, REQUEST_ALBUM);
+        }
     }
 
     public void getImageFromCamera(OnImageSelectListener mListener){
@@ -73,13 +90,22 @@ public class ImageProvider {
         Intent intent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
         intent.putExtra(MediaStore.EXTRA_OUTPUT,
                 Uri.fromFile(tempImage));
-        act.startActivityForResult(intent, REQUEST_CAMERA);
+        if (act == null) {
+            mFragment.startActivityForResult(intent, REQUEST_CAMERA);
+        }else{
+            act.startActivityForResult(intent, REQUEST_CAMERA);
+        }
     }
 
     public void getImageFromNet(OnImageSelectListener mListener){
         this.mListener = mListener;
         Intent intent = new Intent(act,NetImageSearchActivity.class);
-        act.startActivityForResult(intent, REQUEST_NET);
+        if (act == null) {
+            mFragment.startActivityForResult(intent, REQUEST_NET);
+        }else{
+            act.startActivityForResult(intent, REQUEST_NET);
+
+        }
     }
 
     public void onActivityResult(int requestCode, int resultCode, final Intent data){


### PR DESCRIPTION
在fragment中无法使用，而`getActivity().startActivityForResult(...)`导致fragment的`onActivityForResult(...)`无法响应，做了简单的修改。
[网上的解决方法](http://stackoverflow.com/questions/6147884/onactivityresult-not-being-called-in-fragment)
